### PR TITLE
Update goal views with new model attributes

### DIFF
--- a/app/views/goals/_form.html.haml
+++ b/app/views/goals/_form.html.haml
@@ -13,16 +13,15 @@
 
   .row
     .form-group
-      = f.label :Organization, :class => 'col-sm-2 control-label'
+      = f.label :Team, :class => 'col-sm-2 control-label'
       .col-sm-4
-        = f.collection_select :organization_id, Organization.all, :id, :name, {}, {:class => 'form-control'}
+        = f.collection_select :team_id, Team.all, :id, :name, {}, {:class => 'form-control'}
 
   .row
     .form-group
-      = f.label :kind, :class => 'col-sm-2 control-label'
+      = f.label :list, :class => 'col-sm-2 control-label'
       .col-sm-4
-        = f.select :kind, options_for_select(["Scrum Team Support", "Team Goal", "Organizational Goal", "Feature", "Company Goal", "Departmental Goal", "Initiative", "Current Work", "Future Work"],""),{:class => 'form-control'}
-
+        = f.collection_select :list_id, List.all, :id, :name, {}, {:class => 'form-control'}
 
   .row
     %br    

--- a/app/views/goals/index.html.haml
+++ b/app/views/goals/index.html.haml
@@ -4,7 +4,7 @@
   %thead
     %tr
       %th Name
-      %th Kind
+      %th List
       %th
       %th
       %th
@@ -13,7 +13,7 @@
     - @goals.each do |goal|
       %tr
         %td= goal.name
-        %td= goal.kind
+        %td= goal.list.name
         %td= link_to 'Show', goal
         %td= link_to 'Edit', edit_goal_path(goal)
         %td= link_to 'Destroy', goal, :method => :delete, :data => { :confirm => 'Are you sure?' }

--- a/app/views/goals/show.html.haml
+++ b/app/views/goals/show.html.haml
@@ -4,8 +4,8 @@
   %b Name:
   = @goal.name
 %p
-  %b Kind:
-  = @goal.kind
+  %b List:
+  = @goal.list.name
 
 = link_to 'Edit', edit_goal_path(@goal)
 \|


### PR DESCRIPTION
Prior to this commit, the views associated with `goal` referenced
outdated attributes `kind` and `organization`.  This commit removes
those references in favor of the new attribution of `team` and `list`.
With these changes, navigating to the goal pages will no longer result
in runtime errors.
